### PR TITLE
Remove stray whitespace in #include

### DIFF
--- a/benchmarks/source/reset_inout_ptr.cpp
+++ b/benchmarks/source/reset_inout_ptr.cpp
@@ -6,7 +6,7 @@
 //
 //  See http://www.boost.org/libs/out_ptr/ for documentation.
 
-#include <benchmarks/statistics.hpp >
+#include <benchmarks/statistics.hpp>
 
 #include <benchmark/benchmark.h>
 


### PR DESCRIPTION
This trips up compilation on MacOS