### PR TITLE
Fix namespace alias naming in docs

### DIFF
--- a/docs/out_ptr.adoc
+++ b/docs/out_ptr.adoc
@@ -65,7 +65,7 @@ With this library, you now can do exactly this at the call site:
 using zop = ztd::out_ptr;
 
 std::unique_ptr<foo_t> new_foo;
-if (!create_foo(pop::out_ptr(new_foo))) {
+if (!create_foo(zop::out_ptr(new_foo))) {
   // etc. ...
 }
 ----

--- a/docs/out_ptr/caveats.adoc
+++ b/docs/out_ptr/caveats.adoc
@@ -29,7 +29,7 @@ There are a few places where the rules of {cpp} (or a poorly implemented C libra
 using zop = ztd:out_ptr;
 // ...
 if (my_maybe_failing_C_api(
-	pop::out_ptr(my_handle), 56, ID_SOFT_CLS) == 0 
+	zop::out_ptr(my_handle), 56, ID_SOFT_CLS) == 0 
 	&& my_handle) {
 		// do something here if the function returns success (0) 
 		// and "my_handle" is non-null
@@ -44,7 +44,7 @@ It is still safe to use such a construct with if statements if you will check th
 using zop = ztd:out_ptr;
 // ...
 if (SQLITE_OK != sqlite3_open("test.db", 
-	pop::out_ptr(database, sqlite3_close))) {
+	zop::out_ptr(database, sqlite3_close))) {
 	// this usage is just fine
 }
 ----
@@ -54,7 +54,7 @@ if (SQLITE_OK != sqlite3_open("test.db",
 ----
 using zop = ztd:out_ptr;
 if (c_error_t err = my_maybe_failing_C_api(
-	pop::out_ptr(my_handle), 56, ID_SOFT_CLS); 
+	zop::out_ptr(my_handle), 56, ID_SOFT_CLS); 
 	err == 0 && my_handle) {
 		// still wrong
 }
@@ -93,7 +93,7 @@ namespace really::terrible { // C++17 nested namespaces
 int main () {
 	using zop = ztd::out_ptr;
 	// leaks because of do_something_that_throws
-	auto result = really::terrible::api(pop::inout_ptr(my_smart));
+	auto result = really::terrible::api(zop::inout_ptr(my_smart));
 }
 ----
 

--- a/docs/out_ptr/examples.adoc
+++ b/docs/out_ptr/examples.adoc
@@ -54,7 +54,7 @@ using zop = ztd::out_ptr;
 
 size_t& size_ref = p_obj.get_deleter().size;
 std::unique_ptr<Interface, SizedDeleter> obj;
-int ret = CreateBusInterface(..., pop::out_ptr(obj), &size_ref);
+int ret = CreateBusInterface(..., zop::out_ptr(obj), &size_ref);
 if (ret != 0) {
      throw std::runtime_error("deep sadness");
 }
@@ -89,7 +89,7 @@ using zop = ztd::out_ptr;
 
 std::unique_ptr<Numf, DoFree> upNumf;
 /* some work... */
-int ret = posix_memalign(pop::out_ptr<void*>(upNumf), 64, nNumf);
+int ret = posix_memalign(zop::out_ptr<void*>(upNumf), 64, nNumf);
 if (ret != 0) {
      throw std::runtime_error("something went wrong and posix_memalign failed!");
 }

--- a/docs/out_ptr/overview.adoc
+++ b/docs/out_ptr/overview.adoc
@@ -57,7 +57,7 @@ With ztd.out_ptr, we can do better. Get rid of the raw pointer and avoid potenti
 using zop = ztd::out_ptr;
 
 boost::shared_ptr<mll_driver> axis_driver(nullptr);
-mll_errno err = mll_driver_init(pop::out_ptr(axis_driver, mll_driver_free), 
+mll_errno err = mll_driver_init(zop::out_ptr(axis_driver, mll_driver_free), 
 	/* additional args ...*/);
 if (err != MLL_SUCESS) {
 	// ...


### PR DESCRIPTION
There were some missing changes from `pop` to `zop` as in #22.